### PR TITLE
Bootstrap should be local, not CDN

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -13,12 +13,8 @@
   <link rel="shortcut icon" type="image/ico" href="../../images/openmrs-favicon.ico" />
   <link rel="icon" type="image/png" href="../../images/openmrs-favicon.png" />
 
-  
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
-  <link rel="stylesheet" href="../../ms/uiframework/resource/coreapps/styles/patientHeader.css"
-  type="text/css" />
-  <link rel="stylesheet" href="../../ms/uiframework/resource/uicommons/styles/styleguide/index.css"
-  type="text/css" />
+  <link rel="stylesheet" href="../../ms/uiframework/resource/coreapps/styles/patientHeader.css" type="text/css" />
+  <link rel="stylesheet" href="../../ms/uiframework/resource/uicommons/styles/styleguide/index.css" type="text/css" />
   <link rel="stylesheet" href="../../ms/uiframework/resource/appui/styles/header.css" type="text/css" />
   <link rel="stylesheet" href="../../ms/uiframework/resource/uicommons/styles/styleguide/jquery-ui-1.9.2.custom.min.css" type="text/css"/>
 </head>

--- a/app/js/openmrs-owa-labworkflow.jsx
+++ b/app/js/openmrs-owa-labworkflow.jsx
@@ -19,7 +19,8 @@ import exportStore from './export-store';
 
 import routes from './routes';
 
-import '../../node_modules/toastr/build/toastr.css';
+import 'toastr/build/toastr.css';
+import 'bootstrap/dist/css/bootstrap.min.css';
 
 render((
   <Provider store={exportStore}>

--- a/package-lock.json
+++ b/package-lock.json
@@ -2266,6 +2266,11 @@
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
     },
+    "bootstrap": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.4.1.tgz",
+      "integrity": "sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA=="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "babel-eslint": "^9.0.0",
     "babel-jest": "^23.6.0",
     "babel-polyfill": "^6.26.0",
+    "bootstrap": "^3.4.1",
     "classnames": "^2.2.6",
     "connected-react-router": "^4.5.0",
     "date-fns": "^1.30.1",


### PR DESCRIPTION
Looks exactly the same as before. Bootstrap is indeed being used. One example in this page is the breadcrumbs. If bootstrap doesn't load, the home icon and the `>` don't appear.

![Screenshot from 2020-04-23 12-45-16](https://user-images.githubusercontent.com/1031876/80142617-55bc9b80-8560-11ea-900d-999f9dc718d3.png)
