### PR TITLE
UHM-4534 Add Lab ID data entry/view to Lab Result Entry page

### DIFF
--- a/app/js/components/LabResultEntry.jsx
+++ b/app/js/components/LabResultEntry.jsx
@@ -76,7 +76,11 @@ export class LabResultEntry extends PureComponent {
     if (state) {
       const conceptUUID = state.concept.uuid;
       const patientUUID = state.patient.uuid;
-      this.setState({ labOrder: state });
+      console.log(state);
+      this.setState({
+        labOrder: state,
+        accessionNumber: state.accessionNumber || "",
+      });
       dispatch(updateLabOrderWithEncounter(state));
       dispatch(patientAction.getPatient(patientUUID));
       dispatch(constantsActions.fetchConceptAsConstant(labResultsDidNotPerformReasonQuestion, 'labResultsDidNotPerformReasonAnswer'));

--- a/app/js/components/LabResultEntry.jsx
+++ b/app/js/components/LabResultEntry.jsx
@@ -15,7 +15,8 @@ import {
   Grid,
   Row,
   FormGroup,
-  FormControl
+  FormControl,
+  ControlLabel
 } from 'react-bootstrap';
 import moment from 'moment';
 import cn from 'classnames';
@@ -630,7 +631,7 @@ export class LabResultEntry extends PureComponent {
                         </span>
                       </span>
                     </div>
-                    <div className="col-xs-12 col-lg-6 order-date-detail">
+                    <div className="col-xs-12 order-date-detail">
                       <span className="test-details-label">
                         <FormattedMessage
                           id="app.labResultEntry.orderDatelabel"
@@ -643,13 +644,15 @@ export class LabResultEntry extends PureComponent {
                         </span>
                       </span>
                     </div>
-                    <div className="col-xs-12 col-lg-6">
-                      <span className="test-details-label">
+                    <div className="col-xs-12">
+                      <span className="test-details-label col-xs-3">
                         <FormattedMessage
                           id="app.labResultEntry.labId"
                           defaultMessage="Lab ID"
                         />
                         {": "}
+                        </span>
+                        <span className="col-xs-6">
                         <FormControl
                           name={"lab-id"}
                           value={this.state.accessionNumber}
@@ -657,7 +660,7 @@ export class LabResultEntry extends PureComponent {
                             this.setState({ accessionNumber: e.target.value })
                           }
                         />
-                      </span>
+                        </span>
                     </div>
                     <br />
                     <br />

--- a/app/js/components/LabResultEntry.jsx
+++ b/app/js/components/LabResultEntry.jsx
@@ -750,7 +750,7 @@ const mapStateToProps = (state) => {
   const labResultsEntryEncounterType = selectProperty(state, 'labResultsEntryEncounterType');
 
   return {
-    form: state.openmrs.form[formId],
+    form: state.openmrs.form && state.openmrs.form[formId],
     patients,
     selectedPatient,
     selectedLabConcept,

--- a/app/js/components/LabResultEntry.jsx
+++ b/app/js/components/LabResultEntry.jsx
@@ -10,13 +10,12 @@ import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import R from 'ramda';
-import { Field, formValueSelector, change } from 'redux-form';
+import { formValueSelector, change } from 'redux-form';
 import {
   Grid,
   Row,
   FormGroup,
-  FormControl,
-  ControlLabel
+  FormControl
 } from 'react-bootstrap';
 import moment from 'moment';
 import cn from 'classnames';
@@ -651,8 +650,8 @@ export class LabResultEntry extends PureComponent {
                           defaultMessage="Lab ID"
                         />
                         {": "}
-                        </span>
-                        <span className="col-xs-6">
+                      </span>
+                      <span className="col-xs-6">
                         <FormControl
                           name={"lab-id"}
                           value={this.state.accessionNumber}
@@ -660,7 +659,7 @@ export class LabResultEntry extends PureComponent {
                             this.setState({ accessionNumber: e.target.value })
                           }
                         />
-                        </span>
+                      </span>
                     </div>
                     <br />
                     <br />

--- a/app/js/components/LabResultEntry.jsx
+++ b/app/js/components/LabResultEntry.jsx
@@ -76,7 +76,6 @@ export class LabResultEntry extends PureComponent {
     if (state) {
       const conceptUUID = state.concept.uuid;
       const patientUUID = state.patient.uuid;
-      console.log(state);
       this.setState({
         labOrder: state,
         accessionNumber: state.accessionNumber || "",
@@ -654,13 +653,18 @@ export class LabResultEntry extends PureComponent {
                         {": "}
                       </span>
                       <span className="col-xs-6">
-                        <FormControl
-                          name={"lab-id"}
-                          value={this.state.accessionNumber}
-                          onChange={(e) =>
-                            this.setState({ accessionNumber: e.target.value })
-                          }
-                        />
+                        {this.props.form &&
+                        this.props.form.state === "EDITING" ? (
+                          <FormControl
+                            name={"lab-id"}
+                            value={this.state.accessionNumber}
+                            onChange={(e) =>
+                              this.setState({ accessionNumber: e.target.value })
+                            }
+                          />
+                        ) : (
+                          this.state.accessionNumber
+                        )}
                       </span>
                     </div>
                     <br />
@@ -737,7 +741,7 @@ const mapStateToProps = (state) => {
   }
 
   if (formId) {
-    const selector = formValueSelector(formId);
+    const selector = formValueSelector(`formId`);
     const obsFieldName = formUtil.obsFieldName('did-not-perform-checkbox', labResultsDidNotPerformQuestion);
     isDidNotPerformCheckboxSelected = !!(selector(state, obsFieldName));
     encounterDateOrToday = selector(state, 'encounter-datetime') || encounterDateOrToday;
@@ -746,6 +750,7 @@ const mapStateToProps = (state) => {
   const labResultsEntryEncounterType = selectProperty(state, 'labResultsEntryEncounterType');
 
   return {
+    form: state.openmrs.form[formId],
     patients,
     selectedPatient,
     selectedLabConcept,

--- a/app/js/components/LabResultEntry.jsx
+++ b/app/js/components/LabResultEntry.jsx
@@ -119,8 +119,6 @@ export class LabResultEntry extends PureComponent {
             });
         };
         this.setState({ isFormSubmitListenerAttached: true });
-      } else {
-        console.error("No submit button yet!");
       }
     }
   }

--- a/app/js/components/LabResultEntry.jsx
+++ b/app/js/components/LabResultEntry.jsx
@@ -192,7 +192,7 @@ export class LabResultEntry extends PureComponent {
       labResultsEntryEncounterType,
       encounterDateOrToday = new Date(),
       locale,
-    } = this.props;  // note to future programmers: doing this makes your code harder to understand
+    } = this.props;
 
     this.updateEncounterAndIsReady();
     const { encounter, isReady } = this.state;

--- a/app/js/translations/en.json
+++ b/app/js/translations/en.json
@@ -38,6 +38,7 @@
     "app.labResultEntry.urgencylabel": "Urgency",
     "app.labResultEntry.orderNumberlabel": "Order Number:",
     "app.labResultEntry.orderDatelabel": "Order Date:",
+    "app.labResultEntry.labId": "Lab ID",
     "app.labResultsList.title": "Lab Test Results",
     "app.labResultsList.TYPE": "TYPE",
     "app.labResultsList.STATUS": "STATUS",

--- a/tests/components/LabResultEntry/__snapshots__/LabResultEntry.spec.jsx.snap
+++ b/tests/components/LabResultEntry/__snapshots__/LabResultEntry.spec.jsx.snap
@@ -331,7 +331,7 @@ exports[`<LabResultEntry /> component renders correctly with valid props 1`] = `
                     className="fieldset-body"
                   >
                     <div
-                      className="col-xs-7"
+                      className="col-xs-12 col-md-7"
                     >
                       <span
                         className="test-details-label"
@@ -345,7 +345,7 @@ exports[`<LabResultEntry /> component renders correctly with valid props 1`] = `
                             Order Number:
                           </span>
                         </FormattedMessage>
-                         
+                         
                         <span
                           className="test-details"
                         >
@@ -354,7 +354,7 @@ exports[`<LabResultEntry /> component renders correctly with valid props 1`] = `
                       </span>
                     </div>
                     <div
-                      className="col-xs-5"
+                      className="col-xs-12 col-md-5"
                     >
                       <span
                         className="test-details-label"
@@ -368,7 +368,7 @@ exports[`<LabResultEntry /> component renders correctly with valid props 1`] = `
                             Urgency
                           </span>
                         </FormattedMessage>
-                        : 
+                        : 
                         <span
                           className="urgencyDetails urgency routine"
                         >
@@ -377,7 +377,7 @@ exports[`<LabResultEntry /> component renders correctly with valid props 1`] = `
                       </span>
                     </div>
                     <div
-                      className="col-xs-10 order-date-detail"
+                      className="col-xs-12 order-date-detail"
                     >
                       <span
                         className="test-details-label"
@@ -391,13 +391,34 @@ exports[`<LabResultEntry /> component renders correctly with valid props 1`] = `
                             Order Date:
                           </span>
                         </FormattedMessage>
-                         
+                         
                         <span
                           className="test-details"
                         >
                           Aug 30 9:34 AM
                         </span>
                       </span>
+                    </div>
+                    <div
+                      className="col-xs-12"
+                    >
+                      <span
+                        className="test-details-label col-xs-3"
+                      >
+                        <FormattedMessage
+                          defaultMessage="Lab ID"
+                          id="app.labResultEntry.labId"
+                          values={Object {}}
+                        >
+                          <span>
+                            Lab ID
+                          </span>
+                        </FormattedMessage>
+                        : 
+                      </span>
+                      <span
+                        className="col-xs-6"
+                      />
                     </div>
                     <br />
                     <br />


### PR DESCRIPTION
https://pihemr.atlassian.net/browse/UHM-4534

![Screenshot from 2020-05-21 16-45-01](https://user-images.githubusercontent.com/1031876/82617346-a71e7180-9b84-11ea-8c41-b16d71273d2b.png)
![Screenshot from 2020-05-21 17-36-47](https://user-images.githubusercontent.com/1031876/82619082-ce2b7200-9b89-11ea-8a36-5f92631b56c0.png)

![labid](https://user-images.githubusercontent.com/1031876/82617354-abe32580-9b84-11ea-943c-e1d0f0ecea5f.png)

~~Known limitation: if you go to a lab with status Reported or Collected, enter a Lab ID straightaway, then hit "Edit", then immediately hit "Submit", the Lab ID will not be submitted. Not sure whether this is a problem or not.~~

The accession number is shown when in view mode. A text box is shown when in edit mode.