### PR TITLE
Print the react components version in CI logs

### DIFF
--- a/.github/workflows/build-latest.yml
+++ b/.github/workflows/build-latest.yml
@@ -22,6 +22,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - run: npm ci
+      - run: npm list @openmrs/react-components || true
       - run: npm run build --if-present
       - run: npm test
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -23,5 +23,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - run: npm ci
+      - run: npm list @openmrs/react-components || true
       - run: npm run build --if-present
       - run: npm test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - run: npm ci
+      - run: npm list @openmrs/react-components || true
       - run: npm run build --if-present
       - run: npm test
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -383,16 +383,16 @@
       }
     },
     "@fortawesome/fontawesome-common-types": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.3.0.tgz",
-      "integrity": "sha512-CA3MAZBTxVsF6SkfkHXDerkhcQs0QPofy43eFdbWJJkZiq3SfiaH1msOkac59rQaqto5EqWnASboY1dBuKen5w=="
+      "version": "0.2.36",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.36.tgz",
+      "integrity": "sha512-a/7BiSgobHAgBWeN7N0w+lAhInrGxksn13uK7231n2m8EDPE3BMCl9NZLTGrj9ZXfCmC6LM0QLqXidIizVQ6yg=="
     },
     "@fortawesome/fontawesome-svg-core": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.3.0.tgz",
-      "integrity": "sha512-UIL6crBWhjTNQcONt96ExjUnKt1D68foe3xjEensLDclqQ6YagwCRYVQdrp/hW0ALRp/5Fv/VKw+MqTUWYYvPg==",
+      "version": "1.2.36",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.36.tgz",
+      "integrity": "sha512-YUcsLQKYb6DmaJjIHdDWpBIGCcyE/W+p/LMGvjQem55Mm2XWVAP5kWTMKWLv9lwpCVjpLxPyOMOyUocP1GxrtA==",
       "requires": {
-        "@fortawesome/fontawesome-common-types": "^0.3.0"
+        "@fortawesome/fontawesome-common-types": "^0.2.36"
       }
     },
     "@fortawesome/free-solid-svg-icons": {
@@ -401,19 +401,12 @@
       "integrity": "sha512-JLmQfz6tdtwxoihXLg6lT78BorrFyCf59SAwBM6qV/0zXyVeDygJVb3fk+j5Qat+Yvcxp1buLTY5iDh1ZSAQ8w==",
       "requires": {
         "@fortawesome/fontawesome-common-types": "^0.2.36"
-      },
-      "dependencies": {
-        "@fortawesome/fontawesome-common-types": {
-          "version": "0.2.36",
-          "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.36.tgz",
-          "integrity": "sha512-a/7BiSgobHAgBWeN7N0w+lAhInrGxksn13uK7231n2m8EDPE3BMCl9NZLTGrj9ZXfCmC6LM0QLqXidIizVQ6yg=="
-        }
       }
     },
     "@fortawesome/react-fontawesome": {
-      "version": "0.1.17",
-      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.17.tgz",
-      "integrity": "sha512-dX43Z5IvMaW7fwzU8farosYjKNGfRb2HB/DgjVBHeJZ/NSnuuaujPPx0YOdcAq+n3mqn70tyCde2HM1mqbhiuw==",
+      "version": "0.1.18",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.18.tgz",
+      "integrity": "sha512-RwLIB4TZw0M9gvy5u+TusAA0afbwM4JQIimNH/j3ygd6aIvYPQLqXMhC9ErY26J23rDPyDZldIfPq/HpTTJ/tQ==",
       "requires": {
         "prop-types": "^15.8.1"
       }
@@ -570,9 +563,9 @@
       }
     },
     "@openmrs/react-components": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@openmrs/react-components/-/react-components-1.5.2.tgz",
-      "integrity": "sha512-L+ozaeJowbOKd2ycJMAH/H9vpjHfCGAM1V6naf1pZevckcv1vPH+CoS6FdAmzdthS0IxS7kd8A+M7dfmNzYURw==",
+      "version": "1.5.3-pre.2",
+      "resolved": "https://registry.npmjs.org/@openmrs/react-components/-/react-components-1.5.3-pre.2.tgz",
+      "integrity": "sha512-pL1g4LUn8TIURUGQMRu0JMKKikXrGPw7lRcMlcCsSI8N1Z/hXc8fEJ9NDBhTAN2A7TPoF+14Rbx03Iw4niy22Q==",
       "requires": {
         "@fortawesome/fontawesome-svg-core": "^1.2.2",
         "@fortawesome/free-solid-svg-icons": "^5.2.0",
@@ -729,14 +722,14 @@
       "dev": true
     },
     "@types/prop-types": {
-      "version": "15.7.4",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
-      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
+      "version": "15.7.5",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
     },
     "@types/react": {
-      "version": "17.0.39",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.39.tgz",
-      "integrity": "sha512-UVavlfAxDd/AgAacMa60Azl7ygyQNRwC/DsHZmKgNvPmRR5p70AJ5Q9EAmL2NWOJmeV+vVUI4IAP7GZrN8h8Ug==",
+      "version": "18.0.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.14.tgz",
+      "integrity": "sha512-x4gGuASSiWmo0xjDLpm5mPb52syZHJx02VKbqUKdLmKtAwIh63XClGsiTI1K6DO5q7ox4xAsQrU+Gl3+gGXF9Q==",
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -860,7 +853,7 @@
         "prop-types": {
           "version": "15.6.0",
           "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
-          "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
+          "integrity": "sha512-H16NHdiZ8szYSKNkCpmKmS8BCogxyABjJ1AqQknIY2iTpy1xC04egoBAzjKm+WU2pbuNxFonw921dnxR0QYAdw==",
           "requires": {
             "fbjs": "^0.8.16",
             "loose-envify": "^1.3.1",
@@ -1242,7 +1235,7 @@
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
     },
     "asn1": {
       "version": "0.2.6",
@@ -3956,7 +3949,7 @@
     "core-js": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+      "integrity": "sha512-ZiPp9pZlgxpWRu0M+YWbm6+aQ84XEfH1JRXvfOc/fILWI0VKhLC2LX13X1NYq4fULzLMq7Hfh43CSo2/aIaUPA=="
     },
     "core-js-pure": {
       "version": "3.21.1",
@@ -4218,9 +4211,9 @@
       }
     },
     "csstype": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.11.tgz",
-      "integrity": "sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.0.tgz",
+      "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA=="
     },
     "cyclist": {
       "version": "1.0.1",
@@ -8101,7 +8094,7 @@
     "isomorphic-fetch": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "integrity": "sha512-9c4TNAKYXM5PRyVcwUZrF3W09nQ+sO7+jydgs4ZGW9dhsLG2VOlISJABombdQqQRXCwuYG3sYV/puGf5rp0qmA==",
       "requires": {
         "node-fetch": "^1.0.1",
         "whatwg-fetch": ">=0.10.0"
@@ -10086,7 +10079,7 @@
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
     },
     "lodash.escape": {
       "version": "4.0.1",
@@ -10168,7 +10161,7 @@
     "lodash.throttle": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
-      "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
+      "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ=="
     },
     "lodash.uniq": {
       "version": "4.5.0",
@@ -11415,9 +11408,9 @@
       }
     },
     "npm": {
-      "version": "6.14.16",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-6.14.16.tgz",
-      "integrity": "sha512-LMiLGYsVNJfVPlQg7v2NYjG7iRIapcLv+oMunlq7fkXVx0BATCjRu7XyWl0G+iuZzHy4CjtM32QB8ox8juTgaw==",
+      "version": "6.14.17",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-6.14.17.tgz",
+      "integrity": "sha512-CxEDn1ydVRPDl4tHrlnq+WevYAhv4GF2AEHzJKQ4prZDZ96IS3Uo6t0Sy6O9kB6XzqkI+J00WfYCqqk0p6IJ1Q==",
       "requires": {
         "JSONStream": "^1.3.5",
         "abbrev": "~1.1.1",
@@ -11818,7 +11811,7 @@
           },
           "dependencies": {
             "ansi-regex": {
-              "version": "4.1.0",
+              "version": "4.1.1",
               "bundled": true
             },
             "is-fullwidth-code-point": {
@@ -13124,7 +13117,7 @@
           }
         },
         "minimist": {
-          "version": "1.2.5",
+          "version": "1.2.6",
           "bundled": true
         },
         "minizlib": {
@@ -13168,7 +13161,7 @@
           },
           "dependencies": {
             "minimist": {
-              "version": "1.2.5",
+              "version": "1.2.6",
               "bundled": true
             }
           }
@@ -14370,7 +14363,7 @@
           },
           "dependencies": {
             "ansi-regex": {
-              "version": "4.1.0",
+              "version": "4.1.1",
               "bundled": true
             },
             "is-fullwidth-code-point": {
@@ -16987,7 +16980,7 @@
     "react-dom-factories": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/react-dom-factories/-/react-dom-factories-1.0.2.tgz",
-      "integrity": "sha1-63cFxNs2+1AbOqOP91lhaqD/luA="
+      "integrity": "sha512-Bmic2N3oKji7vw9qjDr2dmwHvOATbFSnKy7EH0uT/qjvzIUsiXp6Yquk72LJ3WfMtRnq3ujXMMo7GsJeLPfFWw=="
     },
     "react-fast-compare": {
       "version": "2.0.4",
@@ -17028,9 +17021,9 @@
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "react-onclickoutside": {
-      "version": "6.12.1",
-      "resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.12.1.tgz",
-      "integrity": "sha512-a5Q7CkWznBRUWPmocCvE8b6lEYw1s6+opp/60dCunhO+G6E4tDTO2Sd2jKE+leEnnrLAE2Wj5DlDHNqj5wPv1Q=="
+      "version": "6.12.2",
+      "resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.12.2.tgz",
+      "integrity": "sha512-NMXGa223OnsrGVp5dJHkuKxQ4czdLmXSp5jSV9OqiCky9LOpPATn3vLldc+q5fK3gKbEHvr7J1u0yhBh/xYkpA=="
     },
     "react-overlays": {
       "version": "0.8.3",
@@ -19858,9 +19851,9 @@
       }
     },
     "underscore": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.2.tgz",
-      "integrity": "sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g=="
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.4.tgz",
+      "integrity": "sha512-BQFnUDuAQ4Yf/cYY5LNrK9NCJFKriaRbD9uR1fTeXnBeoa97W0i41qkZfGO9pSo8I5KzjAcSY2XYtdf0oKd7KQ=="
     },
     "union-value": {
       "version": "1.0.1",


### PR DESCRIPTION
I don't know why it says the version is invalid—it matches the one specified in `package.json`, and running `npm list @openmrs/react-components` locally runs successfully. But at least it is printing the installed package version.